### PR TITLE
Allow predefined routes definition for initial vehicles and vehicles created by lists

### DIFF
--- a/symuvia/config/reseau.xsd
+++ b/symuvia/config/reseau.xsd
@@ -3849,6 +3849,11 @@ Le VGP disparaît du réseau après avoir atteint le dernier arrêt de la ligne,
                         <xsd:documentation>Numéro de voie du véhicule à créer</xsd:documentation>
                       </xsd:annotation>
                     </xsd:attribute>
+                    <xsd:attribute name="route" type="xsd:string" use="optional">
+                      <xsd:annotation>
+                        <xsd:documentation>Itinéraire imposé pour le véhicule</xsd:documentation>
+                      </xsd:annotation>
+                    </xsd:attribute>
                   </xsd:complexType>
                 </xsd:element>
               </xsd:sequence>
@@ -5611,6 +5616,12 @@ Le VGP disparaît du réseau après avoir atteint le dernier arrêt de la ligne,
                                       <xsd:annotation>
                                         <xsd:documentation>Destination du véhicule (identifiant de la sortie). Cet attribut doit être obligatoirement présent dans le cas d'une simulation avec un flux de type 'destination' ou 'itineraire'.
 								</xsd:documentation>
+                                      </xsd:annotation>
+                                    </xsd:attribute>
+                                    <xsd:attribute name="route" type="xsd:string"
+                                      use="optional">
+                                      <xsd:annotation>
+                                        <xsd:documentation>Itinéraire imposé pour le véhicule</xsd:documentation>
                                       </xsd:annotation>
                                     </xsd:attribute>
                                   </xsd:complexType>

--- a/symuvia/src/reseau.cpp
+++ b/symuvia/src/reseau.cpp
@@ -1311,7 +1311,7 @@ bool Reseau::InitSimuTraficMeso()
             {
                 std::vector<Tuyau*> iti;
                 iti.push_back(pVeh->GetLink(0));
-                pVeh->GetTrip()->ChangeRemainingPath(iti, pVeh.get());
+                pVeh->GetTrip()->ChangeCurrentPath(iti, 0);
             }
             else
             {
@@ -1326,7 +1326,7 @@ bool Reseau::InitSimuTraficMeso()
                     std::vector<Tuyau*> newIti;
                     newIti.push_back(pVeh->GetLink(0));
                     newIti.insert(newIti.end(), newPaths.front().links.begin(),newPaths.front().links.end());
-                    pVeh->GetTrip()->ChangeRemainingPath(newIti, pVeh.get());
+                    pVeh->GetTrip()->ChangeCurrentPath(newIti, 0);
                 }
                 else
                 {

--- a/symuvia/src/reseau.cpp
+++ b/symuvia/src/reseau.cpp
@@ -1303,8 +1303,8 @@ bool Reseau::InitSimuTraficMeso()
         AddVehicule(pVeh);
         m_nLastVehicleID = max(m_nLastVehicleID, pVeh->GetID()+1);
 
-        // Calcul des itinéraires des véhicules déjà présent sur le réseau à l'instant 0
-        if(IsCptItineraire())
+        // Calcul des itinéraires des véhicules déjà présent sur le réseau à l'instant 0 (pour lesquels on n'a pas d'itinéraire prédéfini)
+        if(IsCptItineraire() && pVeh->GetTrip()->GetFullPath()->size() == 0)
         {
             // Cas particulier origine == destination qui fait boucler à l'infini dijkstra
             if(pVeh->GetLink(0)->GetCnxAssAv() == ((SymuViaTripNode*)pVeh->GetDestination())->GetInputConnexion())
@@ -11698,7 +11698,7 @@ void Reseau::GenerateAssignmentNetwork()
     {
         DOMNode * pXmlNodeTrajs;
         int nID, nVoie;
-        std::string sTr, sTV, sDestination;
+        std::string sTr, sTV, sDestination, sRoute;
         double dbPos, dbVit, dbAcc;
         SymuViaTripNode *pDestination;
 
@@ -11738,6 +11738,21 @@ void Reseau::GenerateAssignmentNetwork()
 
             // Destination
             GetXmlAttributeValue(xmlNode, "destination", sDestination, &logger);
+
+            // Route
+            GetXmlAttributeValue(xmlNode, "route", sRoute, &logger);
+
+            std::deque<std::string> splittedRoute = SystemUtil::split(sRoute, ' ');
+            std::vector<Tuyau*> route;
+            for (size_t iLink = 0; iLink < splittedRoute.size(); iLink++) {
+                Tuyau * pLink = GetLinkFromLabel(splittedRoute[iLink]);
+                if (!pLink) {
+                    logger << Logger::Error << "ERROR : link " << splittedRoute[iLink] << " not found in some initial vehicle's route !" << std::endl;
+                    logger << Logger::Info; // rebascule en mode INFO pour ne pas avoir à reprendre tous les appels aux log en précisant que c'est des INFO. à supprimer si on reprend tous les appels au log.
+                    return;
+                }
+                route.push_back(pLink);
+            }
 
             // Vérifications de l'intégrité des données
             Tuyau* pT = GetLinkFromLabel(sTr);
@@ -11781,6 +11796,7 @@ void Reseau::GenerateAssignmentNetwork()
                 Trip * pTrip = new Trip();
                 TripLeg * pTripLeg = new TripLeg();
                 pTripLeg->SetDestination(pDestination);
+                pTripLeg->SetPath(route);
                 pTrip->AddTripLeg(pTripLeg);
                 pVehicule->SetTrip(pTrip);
                 pVehicule->MoveToNextLeg();
@@ -12210,7 +12226,22 @@ bool Reseau::LoadCreationRepartitions(SymuViaTripNode * pOrigine, DOMNode *pXMLT
                     {
                         GetXmlAttributeValue(xmlChildj, "instant", dbTmp, pChargement);
                         GetXmlAttributeValue(xmlChildj, "num_voie", nVoie, pChargement);
-                        pOrigine->AddCreationVehicule(dbTmp, pTV, pDst, nVoie);
+
+
+                        std::string sRoute;
+                        GetXmlAttributeValue(xmlChildj, "route", sRoute, pChargement);
+                        std::deque<std::string> splittedRoute = SystemUtil::split(sRoute, ' ');
+                        std::vector<Tuyau*> route;
+                        for (size_t iLink = 0; iLink < splittedRoute.size(); iLink++) {
+                            Tuyau * pLink = GetLinkFromLabel(splittedRoute[iLink]);
+                            if (!pLink) {
+                                *pChargement << Logger::Error << "ERROR : link " << splittedRoute[iLink] << " not found in vehicle's route !" << std::endl;
+                                *pChargement << Logger::Info; // rebascule en mode INFO pour ne pas avoir à reprendre tous les appels aux log en précisant que c'est des INFO. à supprimer si on reprend tous les appels au log.
+                                return false;
+                            }
+                            route.push_back(pLink);
+                        }
+                        pOrigine->AddCreationVehicule(dbTmp, pTV, pDst, nVoie, route);
                     }
                     else
                     {

--- a/symuvia/src/usage/SymuViaTripNode.cpp
+++ b/symuvia/src/usage/SymuViaTripNode.cpp
@@ -350,6 +350,13 @@ boost::shared_ptr<Vehicule> SymuViaTripNode::GenerateVehicle
 )
 {
     boost::shared_ptr<Vehicule> pVehicule;
+
+    // if no path, in passed in pIti, use the predefined one if any, and if we are not in directional coefficient mode
+    // and if m_bDemande == false (ie. typeCreationVehicule == "listeVehicules")
+    if ((pIti == NULL || pIti->empty()) && m_pNetwork->IsUsedODMatrix() && !m_bDemande && !m_lstRouteVehiculeACreer.empty()) {
+        pIti = &m_lstRouteVehiculeACreer;
+    }
+
     Connexion * pConnexion = GetOutputConnexion();
     Tuyau * pOutputLink = NULL;						// output link of trip node of origin
 
@@ -906,6 +913,7 @@ boost::shared_ptr<Vehicule> SymuViaTripNode::GenerateVehicle
 			    m_dbCritCreationVeh = creationVeh.dbInstantCreation;
                 m_pTypeVehiculeACreer = creationVeh.pTypeVehicule;
                 m_nVoieACreer = creationVeh.nVoie-1;
+                m_lstRouteVehiculeACreer = creationVeh.route;
                 m_LstCreationsVehicule.erase(m_LstCreationsVehicule.begin() + iVeh);
             }
         }
@@ -1134,7 +1142,8 @@ void SymuViaTripNode::InitLogMatriceOD
     double dbInstant,
     TypeVehicule * pTV,
     SymuViaTripNode * pDest,
-    int nVoie
+    int nVoie,
+    const std::vector<Tuyau*> & route
 )
 {
     CreationVehicule creationVeh;
@@ -1142,6 +1151,7 @@ void SymuViaTripNode::InitLogMatriceOD
     creationVeh.pTypeVehicule = pTV;
     creationVeh.pDest = pDest;
     creationVeh.nVoie = nVoie;
+    creationVeh.route = route;
     m_LstCreationsVehicule.push_back(creationVeh);
 }
 
@@ -2637,6 +2647,7 @@ void CreationVehicule::serialize(Archive & ar, const unsigned int version)
     ar & BOOST_SERIALIZATION_NVP(pTypeVehicule);
     ar & BOOST_SERIALIZATION_NVP(pDest);
     ar & BOOST_SERIALIZATION_NVP(nVoie);
+    ar & BOOST_SERIALIZATION_NVP(route);
 }
 
 template void RepartitionEntree::serialize(boost::archive::xml_woarchive & ar, const unsigned int version);
@@ -2722,6 +2733,7 @@ void SymuViaTripNode::serialize(Archive & ar, const unsigned int version)
     ar & BOOST_SERIALIZATION_NVP(m_pTypeVehiculeACreer);
     ar & BOOST_SERIALIZATION_NVP(m_pDestinationVehiculeACreer);
     ar & BOOST_SERIALIZATION_NVP(m_nVoieACreer);
+    ar & BOOST_SERIALIZATION_NVP(m_lstRouteVehiculeACreer);
 
     ar & BOOST_SERIALIZATION_NVP(m_lstSortiesStationnement);
 

--- a/symuvia/src/usage/SymuViaTripNode.h
+++ b/symuvia/src/usage/SymuViaTripNode.h
@@ -39,6 +39,7 @@ public:
     TypeVehicule * pTypeVehicule;
     SymuViaTripNode * pDest;
     int nVoie;
+    std::vector<Tuyau*> route;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Sérialisation
@@ -183,7 +184,7 @@ public:
     std::deque<SymuViaTripNode*>* GetLstDestinations(){return &m_LstDestinations;}
     void AddDestinations(SymuViaTripNode* pDst);
     
-    void AddCreationVehicule(double dbInstant, TypeVehicule * pTV, SymuViaTripNode * pDest, int nVoie);
+    void AddCreationVehicule(double dbInstant, TypeVehicule * pTV, SymuViaTripNode * pDest, int nVoie, const std::vector<Tuyau*> & route);
     
     // Gestion du log de la matrice OD de l'origine
     int                 GetLogMatriceODSize(){return (int)m_LogMatriceOD.size();};
@@ -330,6 +331,7 @@ protected:
     TypeVehicule*                   m_pTypeVehiculeACreer;
     SymuViaTripNode*                m_pDestinationVehiculeACreer;
     int                             m_nVoieACreer;
+    std::vector<Tuyau*>             m_lstRouteVehiculeACreer;
 
     // Liste des variantes des distributions de motifs
     std::map<TypeVehicule*, std::deque<TimeVariation<CRepMotif> > >               m_lstRepMotif;


### PR DESCRIPTION
Thanks for the Open source release of Open-SymuVia ! 👍 

This PR contains 2 small changes we needed for symuvia's integration in neovya hubsim and might interest others :
- A fix for some stuck vehicles cases (for vehicles on the network from the start of the simulation)
- New "route" attributes in the XSD to allow predefined routes definition for initial vehicles and vehicles created at an origin with "typeCreationVehicule" = "listeVehicules"