### PR TITLE
[BUGFIX] fixed a random crash when calling SymQuit()

### DIFF
--- a/symuvia/src/launcher/SymuViaLauncher.cpp
+++ b/symuvia/src/launcher/SymuViaLauncher.cpp
@@ -18,6 +18,7 @@ namespace po = boost::program_options;
 
 SYMUBRUIT_EXPORT bool SYMUBRUIT_CDECL SymLoadNetwork(std::string sTmpXmlDataFile, std::string sScenarioID = "", std::string sOutdir = "");
 SYMUBRUIT_EXPORT bool SYMUBRUIT_CDECL SymRunNextStep(std::string &sXmlFluxInstant, bool bTrace, bool &bNEnd);
+SYMUBRUIT_EXPORT int SYMUBRUIT_CDECL SymQuit();
 
 int main(int argc, char* argv[])
 {
@@ -77,6 +78,9 @@ int main(int argc, char* argv[])
         else
             std::cout << "Microscopic simulation completed" << std::endl;
     }
+
+    // Terminate properly
+    SymQuit();
 
     return SUCCESS;  
 }

--- a/symuvia/src/reseau.cpp
+++ b/symuvia/src/reseau.cpp
@@ -307,6 +307,8 @@ void Reseau::Initialize()
     m_XmlDocSirane = NULL;
     m_CSVOutputWriter = NULL;
     m_pTravelTimesOutputManager = NULL;
+    m_RobustPointsBackupFile = NULL;
+    
 
     m_bSaveAffectation = false;
 


### PR DESCRIPTION
m_RobustPointsBackupFile was not initialized to NULL, so we could call close() on an uninitialized pointer in Reseau::FinSimuTrafic.

Also added a call to SymQuit at the end of the SymuVia's launcher.